### PR TITLE
Fix Dockerfile.migrations .NET version

### DIFF
--- a/backend/Dockerfile.migrations
+++ b/backend/Dockerfile.migrations
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:9.0
 
 WORKDIR /src
 COPY backend/Multitenant.Api/*.csproj ./Multitenant.Api/


### PR DESCRIPTION
## Summary
- fix Dockerfile for migrations so it uses .NET 9 SDK

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400ceddc18832688507d7dba7b7aaf