### PR TITLE
Add modern tile based homepage

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8,7 +8,7 @@
   --background: #ffffff;
   --foreground: #171717;
 
-  --primary-color: #ff007f; /* magenta */
+  --primary-color: #e6007e; /* magenta */
   --secondary-color: #00ae8d; /* vert 0,174,141 */
 }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,25 +1,27 @@
-// src/app/page.tsx
+import Tile from '../components/Tile'
+
 export default function HomePage() {
   return (
-    <div className="grid grid-cols-4 gap-4 mt-4">
-      <div className="bg-[#00AE8D] text-white p-6 rounded-2xl col-span-2 row-span-2 shadow-lg">
-        <h2 className="text-2xl font-semibold">Grande tuile</h2>
-        <p className="text-sm mt-2">Contenu principal</p>
-      </div>
-
-      <div className="bg-[#e6007e] text-white p-4 rounded-xl col-span-1 shadow-md">
-        <h3 className="font-medium">Tuile moyenne</h3>
-        <p className="text-xs">Autre contenu</p>
-      </div>
-
-      <div className="bg-black text-white p-2 rounded-lg col-span-1 row-span-1 shadow-sm text-center">
-        <span className="text-xs">Petite tuile</span>
-      </div>
-
-      <div className="bg-white border border-gray-300 p-4 rounded-xl col-span-1 row-span-1">
-        <p className="text-sm">Tuile neutre</p>
-      </div>
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+      <Tile
+        href="/dashboard"
+        size="large"
+        className="bg-secondary text-white col-span-2 row-span-2 shadow-lg"
+      >
+        <div>
+          <h2 className="text-2xl font-semibold">Tableau de bord</h2>
+          <p className="text-sm mt-2">Accéder à vos données</p>
+        </div>
+      </Tile>
+      <Tile href="/profil" className="bg-primary text-white shadow-md">
+        Mon profil
+      </Tile>
+      <Tile href="/docs" className="bg-black text-white shadow-md">
+        Documentation
+      </Tile>
+      <Tile href="/support" className="bg-white text-black border shadow-md">
+        Support
+      </Tile>
     </div>
   )
 }
-

--- a/frontend/src/components/Tile.tsx
+++ b/frontend/src/components/Tile.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+interface TileProps {
+  href?: string
+  size?: 'small' | 'medium' | 'large'
+  className?: string
+  children: React.ReactNode
+}
+
+export default function Tile({ href, size = 'medium', className = '', children }: TileProps) {
+  const sizeClass = size === 'large' ? 'tile-large' : size === 'small' ? 'tile-small' : 'tile-medium'
+  const classes = `tile ${sizeClass} ${className}`.trim()
+
+  if (href) {
+    return (
+      <Link href={href} className={classes}>
+        {children}
+      </Link>
+    )
+  }
+
+  return <div className={classes}>{children}</div>
+}


### PR DESCRIPTION
## Summary
- implement Tile component for reusable tile styles
- redesign homepage with grid of color tiles
- tweak magenta color in global styles

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840138cd4b48326a56568a734388fa9