### PR TITLE
Implement tenant resolver middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Un middleware .NET (TenantResolverMiddleware) qui extrait un identifiant de tena
 
 un sous-domaine, un header, ou un jeton JWT
 
+Pour tester l'application vous pouvez :
+* renseigner l'en-tête `X-Tenant-Id` dans vos requêtes HTTP
+* utiliser un nom de domaine de la forme `tenant.votreapp.local`
+* ou fournir un token JWT contenant la claim `tenant_id`
+
 Toutes les requêtes vers la base sont automatiquement filtrées avec le TenantId
 
 L’authentification et les droits peuvent être étendus par tenant

--- a/backend/Multitenant.Api/Controllers/HealthController.cs
+++ b/backend/Multitenant.Api/Controllers/HealthController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Multitenant.Api.Middleware;
 
 namespace Multitenant.Api.Controllers
 {
@@ -9,7 +10,10 @@ namespace Multitenant.Api.Controllers
         [HttpGet]
         public IActionResult Get()
         {
-            return Ok(new { status = "Healthy", timestamp = DateTime.UtcNow });
+            var tenantId = HttpContext.Items[TenantResolverMiddleware.TenantIdItemKey]?.ToString();
+            if (tenantId is null)
+                return BadRequest("Tenant not resolved");
+            return Ok(new { status = "Healthy", timestamp = DateTime.UtcNow, tenant = tenantId });
         }
     }
 }

--- a/backend/Multitenant.Api/Middleware/TenantResolverMiddleware.cs
+++ b/backend/Multitenant.Api/Middleware/TenantResolverMiddleware.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Multitenant.Api.Middleware
+{
+    /// <summary>
+    /// Middleware used to resolve the tenant identifier from the incoming request.
+    /// It looks for the tenant in the following order:
+    /// 1. The "X-Tenant-Id" header
+    /// 2. The subdomain of the host (e.g. {tenant}.example.com)
+    /// 3. The authenticated user's JWT claims ("tenant_id")
+    /// </summary>
+    public class TenantResolverMiddleware
+    {
+        public const string TenantIdItemKey = "TenantId";
+        private const string TenantHeader = "X-Tenant-Id";
+        private readonly RequestDelegate _next;
+
+        public TenantResolverMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            string? tenantId = null;
+
+            // 1. Header
+            if (context.Request.Headers.TryGetValue(TenantHeader, out var headerValues))
+            {
+                tenantId = headerValues.FirstOrDefault();
+            }
+
+            // 2. Subdomain
+            if (string.IsNullOrEmpty(tenantId))
+            {
+                var host = context.Request.Host.Host; // without port
+                var parts = host.Split('.');
+                if (parts.Length > 2)
+                {
+                    tenantId = parts[0];
+                }
+            }
+
+            // 3. JWT claim
+            if (string.IsNullOrEmpty(tenantId) && context.User?.Identity?.IsAuthenticated == true)
+            {
+                tenantId = context.User.Claims.FirstOrDefault(c => c.Type == "tenant_id")?.Value;
+            }
+
+            if (!string.IsNullOrWhiteSpace(tenantId))
+            {
+                context.Items[TenantIdItemKey] = tenantId;
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/backend/Multitenant.Api/Program.cs
+++ b/backend/Multitenant.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Multitenant.Api.Data;
+using Multitenant.Api.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +14,7 @@ builder.Services.AddControllers();
 var app = builder.Build();
 
 // Configuration du pipeline HTTP
+app.UseMiddleware<TenantResolverMiddleware>();
 app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
## Summary
- add TenantResolverMiddleware to inspect headers, subdomains and JWT claims
- wire middleware into the API request pipeline
- update controllers to require a resolved tenant ID
- document tenant resolution in README

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840181f708c83269c1d74043d06b4d7