### PR TITLE
Remove appsettings connection string

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ASPNETCORE_ENVIRONMENT=Development
 # Port d'écoute interne (configuré dans Dockerfile ou launchSettings.json)
 ASPNETCORE_URLS=http://+:8080
 
-# Chaîne de connexion à PostgreSQL
+# Chaîne de connexion PostgreSQL (uniquement via variable d'environnement)
 ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Username=dev;Password=devpass;Database=multitenant_db
 
 # ----------------------------

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Lancer les services :
 
 
 docker-compose up --build
+Avant de démarrer, copiez le fichier `.env.example` vers `.env` et ajustez la variable
+`ConnectionStrings__DefaultConnection`. Le backend lit **uniquement** cette
+variable d'environnement pour se connecter à PostgreSQL.
 Accès :
 
 API Backend (.NET) : http://localhost:5000

--- a/backend/Multitenant.Api/Program.cs
+++ b/backend/Multitenant.Api/Program.cs
@@ -3,9 +3,11 @@ using Multitenant.Api.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Ajouter la configuration de PostgreSQL
+// Ajouter la configuration de PostgreSQL depuis les variables d'environnement
+var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string not configured");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseNpgsql(connectionString));
 
 // Autres services
 builder.Services.AddControllers();

--- a/backend/Multitenant.Api/appsettings.json
+++ b/backend/Multitenant.Api/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Host=postgres;Port=5432;Username=dev;Password=devpass;Database=multitenant_db"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information"


### PR DESCRIPTION
## Summary
- remove the DefaultConnection entry from `appsettings.json`
- fetch the connection string via environment variable in `Program.cs`
- update `.env.example` comment
- document the new environment variable requirement in README

## Testing
- `dotnet build backend/Multitenant.Api/Multitenant.Api.csproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840185311548326bb4f216aaa6edb87