### PR TITLE
Enable Swagger and HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ PostgreSQL : localhost:5432, utilisateur dev, mot de passe devpass
 
 Kibana : http://localhost:5601
 
+Swagger UI : http://localhost:5000/swagger
+
 🗂️ Fonctionnalité multitenant
 Le système repose sur :
 

--- a/backend/Multitenant.Api/Multitenant.Api.csproj
+++ b/backend/Multitenant.Api/Multitenant.Api.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
 </Project>

--- a/backend/Multitenant.Api/Program.cs
+++ b/backend/Multitenant.Api/Program.cs
@@ -9,10 +9,23 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 
 // Autres services
 builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader());
+});
 
 var app = builder.Build();
 
 // Configuration du pipeline HTTP
+app.UseHttpsRedirection();
+app.UseCors("AllowAll");
+app.UseSwagger();
+app.UseSwaggerUI();
 app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
## Summary
- add Swagger dependency
- register Swagger, HTTPS and CORS in the API
- document Swagger endpoint

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684018533524832696dedfd5b121f082