### PR TITLE
Add automatic migration update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Lancer les services :
 
 
 docker-compose up --build
+Le conteneur backend applique automatiquement les migrations EF Core en exécutant
+`dotnet ef database update`. Si vous lancez l'API manuellement, exécutez cette
+commande pour mettre à jour le schéma avant de démarrer l'application.
 Accès :
 
 API Backend (.NET) : http://localhost:5000

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,4 +14,12 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/publish .
 
-ENTRYPOINT ["dotnet", "Multitenant.Api.dll"]
+# Install dotnet-ef tool to apply migrations at startup
+RUN dotnet tool install --global dotnet-ef
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+# Copy startup script that runs migrations if needed
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Apply migrations if schema is outdated
+if dotnet ef database update --no-build; then
+  echo "Database checked/updated"
+else
+  echo "Failed to update database" >&2
+fi
+
+exec dotnet Multitenant.Api.dll


### PR DESCRIPTION
## Summary
- add backend entrypoint script to run migrations
- update backend Dockerfile to use the entrypoint
- document automatic migration update in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840185e6e40832692fcecff6792ee98